### PR TITLE
Add Open SDK to Featured Projects with deep-link to modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,6 +261,7 @@
                 <h2 class="section-title">Featured Projects</h2>
                 <div class="links-list">
                     <a href="https://lucaspfeiffer.earth/projects" class="link" target="_blank">Timeline</a>
+                    <a href="https://lucaspfeiffer.earth/projects#2026-open-sdk" class="link" target="_blank">Open SDK</a>
                     <a href="https://toolsacowboywoulduse.com" class="link" target="_blank">Tools a cowboy would use</a>
                     <a href="https://toolsacowboywoulduse.com/?view=store" class="link" target="_blank">TACWU 2026 Summer Collection</a>
                     <a href="https://toolsacowboywoulduse.com/01-dawnanddusk/" class="link" target="_blank">Dawn and Dusk</a>

--- a/projects.html
+++ b/projects.html
@@ -1155,12 +1155,12 @@
         // Initialize
         document.addEventListener('DOMContentLoaded', () => {
             renderProjects();
-            
+
             // Set initial current year to most recent year (first in the list)
             const years = [...new Set(projects.map(p => p.year))].sort((a, b) => b - a);
             if (years.length > 0) {
                 document.querySelector('.current-year').textContent = years[0];
-                
+
                 // Auto-scroll to first year section (slight delay to let rendering complete)
                 setTimeout(() => {
                     const firstYearSection = document.getElementById(years[0]);
@@ -1175,6 +1175,18 @@
                     alignTimelineWithYear();
                 }, 100);
             }
+
+            // If the URL has a project hash (e.g. #2026-open-sdk), open that project's modal
+            const openProjectFromHash = () => {
+                const hash = window.location.hash.slice(1);
+                if (!hash) return;
+                const projectElement = document.getElementById(hash);
+                if (projectElement && projectElement.classList.contains('project')) {
+                    openModal(projectElement);
+                }
+            };
+            setTimeout(openProjectFromHash, 200);
+            window.addEventListener('hashchange', openProjectFromHash);
             
             // Make current year clickable to open a menu on mobile
             document.querySelector('.current-year').addEventListener('click', function() {


### PR DESCRIPTION
## Summary
- Add Open SDK link in Featured Projects → `/projects#2026-open-sdk`
- Projects page now opens the matching project's modal on load if the URL hash matches a project id
- Reacts to `hashchange` so anchor changes within the page also open modals

## Test plan
- [ ] Home page Featured Projects shows the new Open SDK link
- [ ] Clicking it lands on the timeline with the Open SDK modal open
- [ ] Direct visits to `/projects` (no hash) still behave as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)