### PR TITLE
Rename Timeline link to Projects Timeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,7 +260,7 @@
             <div class="section">
                 <h2 class="section-title">Featured Projects</h2>
                 <div class="links-list">
-                    <a href="https://lucaspfeiffer.earth/projects" class="link" target="_blank">Timeline</a>
+                    <a href="https://lucaspfeiffer.earth/projects" class="link" target="_blank">Projects Timeline</a>
                     <a href="https://lucaspfeiffer.earth/projects#2026-open-sdk" class="link" target="_blank">Open SDK</a>
                     <a href="https://toolsacowboywoulduse.com" class="link" target="_blank">Tools a cowboy would use</a>
                     <a href="https://toolsacowboywoulduse.com/?view=store" class="link" target="_blank">TACWU 2026 Summer Collection</a>


### PR DESCRIPTION
Renames the Featured Projects "Timeline" link to "Projects Timeline" for clarity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)