### PR TITLE
fix broken Dawn and Dusk link to renamed cowboy site path

### DIFF
--- a/index.html
+++ b/index.html
@@ -264,7 +264,7 @@
                     <a href="https://lucaspfeiffer.earth/projects#2026-open-sdk" class="link" target="_blank">Open SDK</a>
                     <a href="https://toolsacowboywoulduse.com" class="link" target="_blank">Tools a cowboy would use</a>
                     <a href="https://toolsacowboywoulduse.com/?view=store" class="link" target="_blank">TACWU 2026 Summer Collection</a>
-                    <a href="https://toolsacowboywoulduse.com/01-dawnanddusk/" class="link" target="_blank">Dawn and Dusk</a>
+                    <a href="https://toolsacowboywoulduse.com/dawnanddusk/" class="link" target="_blank">Dawn and Dusk</a>
                     <a href="https://dawnanddusk.earth" class="link" target="_blank">dawnanddusk.earth</a>
                 </div>
             </div>


### PR DESCRIPTION
The `toolsacowboywoulduse.com` Dawn and Dusk path was renamed from `/01-dawnanddusk/` to `/dawnanddusk/`, leaving the main page link 404ing.

- Old: `https://toolsacowboywoulduse.com/01-dawnanddusk/` → 404
- New: `https://toolsacowboywoulduse.com/dawnanddusk/` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)