### PR TITLE
fix mobile scroll jitter from dvh resizing mid-scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@
                 padding: 32px;
                 height: auto;
                 overflow-y: auto;
-                min-height: 100dvh;
+                min-height: 100svh;
             }
 
             .content-wrapper {
@@ -214,7 +214,7 @@
             }
 
             .hero-section {
-                min-height: calc(100dvh - 64px);
+                min-height: calc(100svh - 64px);
                 padding-top: 0;
                 display: flex;
                 flex-direction: column;
@@ -354,31 +354,6 @@
             setTimeout(() => {
                 document.body.classList.add('transitions-enabled');
             }, 100);
-
-            // Improved scroll check
-            function checkScroll() {
-                const content = document.querySelector('.content-wrapper');
-                const viewportHeight = window.visualViewport ? window.visualViewport.height : window.innerHeight;
-                
-                if (content.offsetHeight + 148 > viewportHeight) { // 108px top + 40px bottom
-                    document.body.classList.add('needs-scroll');
-                    document.documentElement.classList.add('needs-scroll');
-                } else {
-                    document.body.classList.remove('needs-scroll');
-                    document.documentElement.classList.remove('needs-scroll');
-                }
-            }
-
-            // Check more frequently during load
-            checkScroll();
-            setTimeout(checkScroll, 100);
-            setTimeout(checkScroll, 500);
-            
-            // Check on resize and viewport changes
-            window.addEventListener('resize', checkScroll);
-            if (window.visualViewport) {
-                window.visualViewport.addEventListener('resize', checkScroll);
-            }
         });
 
         // Update intervals


### PR DESCRIPTION
## Problem
Mobile web showed scroll jitter. As the browser toolbar collapses/expands during a swipe, `dvh` units resize the vertically-centered hero section live, shifting everything below it and fighting the scroll.

## Fix
- Switch the two mobile `min-height` values from `dvh` → `svh` (the stable toolbar-expanded height, which doesn't change during scroll).
- Remove the dead `checkScroll` handler and its `resize`/`visualViewport` listeners — it read `offsetHeight` every scroll frame (forcing layout) only to toggle a `needs-scroll` class that no CSS rule used.

Trade-off: `svh` sizes the hero to the smaller viewport, leaving a little extra space below it when the toolbar is hidden — the standard stable choice to avoid jitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)